### PR TITLE
Load a custom LLDB py script to enhance the display of Odin slices, maps, strings, and unions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +362,7 @@ dependencies = [
 name = "odin"
 version = "0.3.2"
 dependencies = [
+ "base64",
  "serde",
  "serde_json",
  "zed_extension_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ crate-type = ["cdylib"]
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 zed_extension_api = "0.7.0"
+base64 = "0.22.1"

--- a/resources/lldb/odin.py
+++ b/resources/lldb/odin.py
@@ -1,0 +1,288 @@
+# Original author: laytan (https://gist.github.com/laytan/a94c323a84cef7bcfbdf6d21987fd5a9)
+# Modifications by: harold-b (https://gist.github.com/harold-b/ef16a5c3ebcceccfc2bc7a5c5dd0058d)
+# Modifications by: adneufeld
+
+import logging
+import math
+
+import lldb
+
+log = logging.getLogger(__name__)
+
+
+def is_slice_type(t, internal_dict):
+    return (
+        t.name.startswith("[]") or t.name.startswith("[dynamic]")
+    ) and not t.name.endswith("]")
+
+
+def slice_summary(value, internal_dict):
+    value = value.GetNonSyntheticValue()
+    length = value.GetChildMemberWithName("len").unsigned
+    data = value.GetChildMemberWithName("data")
+
+    pointee = data.deref
+    type_name = pointee.type.GetDisplayTypeName()
+
+    return f"[{length}]{type_name}"
+
+
+class SliceChildProvider:
+    CHUNK_COUNT = 2000
+
+    def __init__(self, val, dict):
+        self.val = val
+        self.update()
+
+    def update(self):
+        val = self.val
+
+        self.len = val.GetChildMemberWithName("len").unsigned
+        self.data_val = val.GetChildMemberWithName("data")
+        assert self.data_val.type.is_pointer
+
+        is_chunked = self.len > SliceChildProvider.CHUNK_COUNT
+        self.chunked_len = (
+            0
+            if not is_chunked
+            else math.ceil(self.len / SliceChildProvider.CHUNK_COUNT)
+        )
+
+        return False
+
+    def num_children(self):
+        return self.chunked_len if self.chunked_len > 0 else self.len
+
+    def get_child_at_index(self, index):
+        length = self.num_children()
+        assert index >= 0 and index < length
+
+        first = self.data_val.deref
+
+        if self.chunked_len > 0:
+            chunk_size = SliceChildProvider.CHUNK_COUNT
+
+            array_len = min(chunk_size, self.len - index * chunk_size)
+            arr_type = first.type.GetArrayType(array_len)
+            offset = index * first.size * chunk_size
+
+            range_start = index * chunk_size
+
+            return self.data_val.CreateChildAtOffset(
+                f"[{range_start}..<{range_start + array_len}]", offset, arr_type
+            )
+
+        offset = index * first.size
+        return self.data_val.CreateChildAtOffset(f"[{index}]", offset, first.type)
+
+
+def is_string_type(t, internal_dict):
+    return t.name == "string"
+
+
+def string_summary(value, internal_dict):
+    pointer = value.GetChildMemberWithName("data").GetValueAsUnsigned(0)
+    length = value.GetChildMemberWithName("len").GetValueAsSigned(0)
+    if pointer == 0:
+        return False
+    if length == 0:
+        return '""'
+    error = lldb.SBError()
+    string_data = value.process.ReadMemory(pointer, length, error)
+    return '"{}"'.format(string_data.decode("utf-8"))
+
+
+def is_map_type(t, internal_dict):
+    return t.name.startswith("map[")
+
+
+class MapChildProvider:
+    def __init__(self, val, dict):
+        self.val = val
+
+    def num_children(self):
+        return (self.val.GetChildMemberWithName("len").GetValueAsSigned() * 2) + 1
+
+    def get_child_at_index(self, index):
+        data = self.val.GetChildMemberWithName("data")
+        tkey = data.GetChildMemberWithName("key").type
+        tval = data.GetChildMemberWithName("value").type
+        hash_field = data.GetChildMemberWithName("hash")
+        key_cell = data.GetChildMemberWithName("key_cell")
+        value_cell = data.GetChildMemberWithName("value_cell")
+
+        raw_data = data.GetValueAsUnsigned()
+        key_ptr = raw_data & ~63
+        cap_log2 = raw_data & 63
+        cap = 0 if cap_log2 <= 0 else 1 << cap_log2
+
+        key_cell_info = self.cell_info(tkey, key_cell)
+        value_cell_info = self.cell_info(tval, value_cell)
+
+        size_of_hash = hash_field.size
+        assert size_of_hash == 8
+
+        value_ptr = self.cell_index(key_ptr, key_cell_info, cap)
+        hash_ptr = self.cell_index(value_ptr, value_cell_info, cap)
+
+        error = lldb.SBError()
+
+        # Last one, the capacity.
+        if index == self.num_children() - 1:
+            cap_data = lldb.SBData.CreateDataFromInt(cap)
+            return self.val.CreateValueFromData(
+                "cap", cap_data, self.val.GetChildMemberWithName("len").type
+            )
+
+        wants_key = index % 2 == 0
+        index = int(index / 2)
+
+        key_index = 0
+        for i in range(cap):
+            TOMBSTONE_MASK = 1 << (size_of_hash * 8 - 1)
+
+            offset_hash = hash_ptr + i * size_of_hash
+
+            hash_val = self.val.process.ReadUnsignedFromMemory(
+                offset_hash, size_of_hash, error
+            )
+            if not error.success:
+                print(error)
+                continue
+            elif hash_val == 0 or (hash_val & TOMBSTONE_MASK) != 0:
+                continue
+
+            offset_key = self.cell_index(key_ptr, key_cell_info, i)
+            offset_value = self.cell_index(value_ptr, value_cell_info, i)
+
+            if index == key_index:
+                if wants_key:
+                    return self.val.CreateValueFromAddress(f"[{i}]", offset_key, tkey)
+                else:
+                    return self.val.CreateValueFromAddress(f"[{i}]", offset_value, tval)
+
+            key_index += 1
+
+        print("not found")
+
+    def cell_info(self, typev, cell_type):
+        elements_per_cell = 0
+
+        if typev.size != cell_type.size:
+            array_type = cell_type.children[0].type
+            if array_type.size > 0 and typev.size > 0:
+                elements_per_cell = array_type.size / typev.size
+
+        if elements_per_cell == 0:
+            elements_per_cell = 1
+
+        return CellInfo(typev.size, cell_type.size, elements_per_cell)
+
+    def cell_index(self, base, info, index):
+        cell_index = 0
+        data_index = 0
+        if info.elements_per_cell == 1:
+            return base + (index * info.size_of_cell)
+        elif info.elements_per_cell == 2:
+            cell_index = index >> 1
+            data_index = index & 1
+        elif info.elements_per_cell == 4:
+            cell_index = index >> 2
+            data_index = index & 3
+        elif info.elements_per_cell == 8:
+            cell_index = index >> 3
+            data_index = index & 7
+        elif info.elements_per_cell == 16:
+            cell_index = index >> 4
+            data_index = index & 15
+        elif info.elements_per_cell == 32:
+            cell_index = index >> 5
+            data_index = index & 31
+        else:
+            cell_index = index / info.elements_per_cell
+            data_index = index % info.elements_per_cell
+
+        return (
+            base + (cell_index * info.size_of_cell) + (data_index * info.size_of_type)
+        )
+
+
+class CellInfo:
+    def __init__(self, size_of_type, size_of_cell, elements_per_cell):
+        self.size_of_type = size_of_type
+        self.size_of_cell = size_of_cell
+        self.elements_per_cell = elements_per_cell
+
+
+class UnionChildProvider:
+    def __init__(self, val, dict):
+        self.val = val
+
+    def update(self):
+        self.children = self.val.children
+        self.variant_index = self.children[0].unsigned
+        return False
+
+    def num_children(self):
+        return len(self.children) - 1
+
+    def get_child_at_index(self, index):
+        value = self.val
+
+        variant_index = index + 1
+        variant = self.children[variant_index]
+        name = variant.type.GetDisplayTypeName()
+        # offset        = variant.addr.offset - value.addr.offset
+        selected = "*" if self.variant_index == variant_index else ""
+
+        field_name = f"{selected}v{variant_index}({name})"
+        # c = value.CreateChildAtOffset( field_name, offset, variant.GetType() )
+        c = value.CreateValueFromData(field_name, variant.data, variant.type)
+
+        return c
+
+
+def is_type_union(t, internal_dict):
+    if t.type != lldb.eTypeClassUnion:
+        return False
+
+    tag = t.GetFieldAtIndex(0)
+    return tag and tag.IsValid() and tag.name == "tag"
+
+
+def union_summary(value, internal_dict):
+    if value.IsSynthetic():
+        value = value.GetNonSyntheticValue()
+
+    tag = value.GetChildAtIndex(0)
+    assert tag.name == "tag"
+    # tag = value.GetChildMemberWithName("tag")
+
+    variant_name = f"v{tag.unsigned}"
+    variant = value.GetChildMemberWithName(variant_name)
+    # variant_type = variant.type.GetDisplayTypeName()
+
+    return f"{variant}"
+
+
+def __lldb_init_module(debugger, unused):
+    debugger.HandleCommand(
+        "type summary add --recognizer-function --python-function odin.union_summary odin.is_type_union"
+    )
+    debugger.HandleCommand(
+        "type synth add --recognizer-function --python-class odin.UnionChildProvider odin.is_type_union"
+    )
+
+    debugger.HandleCommand(
+        "type summary add --recognizer-function --python-function odin.string_summary odin.is_string_type"
+    )
+    debugger.HandleCommand(
+        "type synth add --recognizer-function --python-class odin.SliceChildProvider odin.is_slice_type"
+    )
+    debugger.HandleCommand(
+        "type summary add --recognizer-function --python-function odin.slice_summary odin.is_slice_type"
+    )
+
+    debugger.HandleCommand(
+        "type synth add --recognizer-function --python-class odin.MapChildProvider odin.is_map_type"
+    )

--- a/src/odin.rs
+++ b/src/odin.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose, Engine as _};
 use std::fs;
 use zed::{
     BuildTaskDefinition, BuildTaskDefinitionTemplatePayload, BuildTaskTemplate, DebugRequest,
@@ -16,6 +17,8 @@ struct OdinExtension {
 }
 
 const GITHUB_REPO: &str = "DanielGavin/ols";
+
+const ODIN_SCRIPT: &str = include_str!("../resources/lldb/odin.py");
 
 impl OdinExtension {
     fn language_server_binary_path(
@@ -399,8 +402,20 @@ impl zed::Extension for OdinExtension {
             cwd: build_task.cwd.clone(),
         };
 
-        // Config is Null - the actual launch config comes from run_dap_locator
-        let config = serde_json::to_string(&serde_json::Value::Null).ok()?;
+        let mut config_map = serde_json::Map::new();
+
+        let encoded_script = general_purpose::STANDARD.encode(ODIN_SCRIPT);
+        let exec_command = format!(
+            "script import base64, types; odin = types.SimpleNamespace(); exec(base64.b64decode('{}').decode(), odin.__dict__); odin.__dict__['__lldb_init_module'](lldb.debugger, {{}})",
+            encoded_script
+        );
+
+        config_map.insert(
+            "preRunCommands".to_string(),
+            serde_json::json!(vec![exec_command]),
+        );
+
+        let config = serde_json::to_string(&config_map).ok()?;
 
         // Remove 'run: ' from the task label, since 'debug: ' will be prepended by default
         let label = resolved_label


### PR DESCRIPTION
# Problem

When debugging Odin programs in Zed using this Odin extension there are known limitations with how the Odin binary is presented via LLDB which cause certain kinds of variables to not be fully viewable in the debug inspector. For example, when viewing a slice type it can be expanded to show the len and the first element of the slice but it does not show any more elements. See the first images below for the current state of debugging of these data types:

slice: 
<img width="366" height="276" alt="image" src="https://github.com/user-attachments/assets/b70bf3a0-e2d6-4bdd-8a4c-1317ebd1a3bc" />

map:
<img width="352" height="222" alt="image" src="https://github.com/user-attachments/assets/6669e2ec-92c4-4979-92fa-b13ce71589f9" />

string: 
<img width="365" height="31" alt="image" src="https://github.com/user-attachments/assets/ca9a485f-55f2-4486-a24f-78f957974b8c" />

union:
<img width="368" height="126" alt="image" src="https://github.com/user-attachments/assets/3c1b84d3-f5b9-427b-a9c1-6d52dc0f5c00" />

# Solution

One workaround for this issue that Odin community members use is to load a py script in LLDB which parses certain Odin-isms like above into a more readable format to enable developers to properly inspect into the elements. Specifically this LLDB py script improves the display for: slices, maps, strings (summary), and union types. 

To implement this solution into the Zed Odin extension, the `odin.py` file is included within the extension directory then the file is loaded, encoded, and passed into the LLDB console as an exec command when the debugger is started. Based on my research this means that the script is executed once at startup time then registered into the LLDB module/script system and used going forward.  

slice:
<img width="373" height="316" alt="image" src="https://github.com/user-attachments/assets/d31adb74-379c-44bb-b9aa-aead87a37639" />

map:
<img width="356" height="174" alt="image" src="https://github.com/user-attachments/assets/8b532c4f-c627-47d1-a855-e3e13a7f5d00" />

string:
<img width="370" height="34" alt="image" src="https://github.com/user-attachments/assets/9ebc2fa3-62f8-41b4-9732-dee377b61494" />

union:
<img width="285" height="129" alt="image" src="https://github.com/user-attachments/assets/c52253af-11b4-41f0-9b76-05088a18fe3b" />

Please let me know if you are interested in this contribution or if you'd like any further changes on the design! I reviewed the repo and didn't see any tests on this but I am not very familiar with Zed extensions so if tests are needed I can add those as well if you can point me in the right direction. 
