### PR TITLE
Fix error running debug task on Windows

### DIFF
--- a/src/odin.rs
+++ b/src/odin.rs
@@ -390,7 +390,7 @@ impl zed::Extension for OdinExtension {
             ""
         };
         let out_name = format!("debug_build{}", extension);
-        build_args.push(format!("-out:{}", out_name).into());
+        build_args.push(format!("-out:{}", out_name));
 
         // Add -debug flag if not present
         if !build_args.contains(&"-debug".into()) {

--- a/src/odin.rs
+++ b/src/odin.rs
@@ -383,7 +383,14 @@ impl zed::Extension for OdinExtension {
         build_args[0] = "build".to_string();
 
         // Add -out flag to control output name
-        build_args.push("-out:debug_build".into());
+        let (platform, _) = zed::current_platform();
+        let extension = if platform == zed::Os::Windows {
+            ".exe"
+        } else {
+            ""
+        };
+        let out_name = format!("debug_build{}", extension);
+        build_args.push(format!("-out:{}", out_name).into());
 
         // Add -debug flag if not present
         if !build_args.contains(&"-debug".into()) {
@@ -446,7 +453,13 @@ impl zed::Extension for OdinExtension {
 
         // Construct absolute path to the binary, since lldb-dap requires absolute paths
         let cwd = build_task.cwd.as_ref().ok_or("No cwd in build task")?;
-        let program = format!("{}/{}", cwd, output_name);
+        let (platform, _) = zed::current_platform();
+        let separator = if platform == zed::Os::Windows {
+            "\\"
+        } else {
+            "/"
+        };
+        let program = format!("{}{}{}", cwd, separator, output_name);
 
         let request = LaunchRequest {
             program: program,


### PR DESCRIPTION
Within the Odin extension there is some code that builds the absolute path for the debug binary. However this code assumes the binary has no extension. This does not work as expected on Windows because it needs a `.exe` path on that platform. The error produced is: “Output path <project_path>/debug_build must have an appropriate extension.”

To resolve it we can just do a quick platform check and build the path with the needed extension on Windows. 