### PR TITLE
Set hard tabs as default

### DIFF
--- a/languages/odin/config.toml
+++ b/languages/odin/config.toml
@@ -4,6 +4,7 @@ path_suffixes = ["odin"]
 line_comments = ["// "]
 block_comment = ["/* ", " */"]
 autoclose_before = ";:.,=}])>"
+hard_tabs = true
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },


### PR DESCRIPTION
Using tab for indentation is Odin's convention, and OLS doesn't respect equest for spaces. Not setting it causes wrong indentation and not having it as default has been a source frustration for users that don't configure external formatter.