### PR TITLE
Add debug test tasks

### DIFF
--- a/src/odin.rs
+++ b/src/odin.rs
@@ -474,6 +474,7 @@ impl zed::Extension for OdinExtension {
         // Remove the prefix from the task label, since 'debug: ' will be prepended by default if no prefix is provided
         let base_label = resolved_label
             .strip_prefix("run: ")
+            .or_else(|| resolved_label.strip_prefix("test: "))
             .unwrap_or(&resolved_label) // Both sides are now &str
             .to_string();
 

--- a/src/odin.rs
+++ b/src/odin.rs
@@ -471,19 +471,12 @@ impl zed::Extension for OdinExtension {
         // Config is Null - the actual launch config comes from run_dap_locator
         let config = serde_json::to_string(&serde_json::Value::Null).ok()?;
 
-        // Remove the prefix from the task label, since 'debug: ' will be prepended by default if no prefix is provided
-        let base_label = resolved_label
+        // Remove 'run: ' from the task label, since 'debug: ' will be prepended by default
+        let label = resolved_label
+            .clone()
             .strip_prefix("run: ")
-            .or_else(|| resolved_label.strip_prefix("test: "))
             .unwrap_or(&resolved_label)
             .to_string();
-
-        // Add a special prefix to clarify debugging tests
-        let label = if is_test {
-            format!("debug test: {}", base_label)
-        } else {
-            base_label
-        };
 
         Some(DebugScenario {
             adapter: debug_adapter_name,

--- a/src/odin.rs
+++ b/src/odin.rs
@@ -471,12 +471,20 @@ impl zed::Extension for OdinExtension {
         // Config is Null - the actual launch config comes from run_dap_locator
         let config = serde_json::to_string(&serde_json::Value::Null).ok()?;
 
-        // Remove 'run: ' from the task label, since 'debug: ' will be prepended by default
-        let label = resolved_label
-            .clone()
-            .strip_prefix("run: ")
-            .unwrap_or(&resolved_label)
-            .to_string();
+        // Update the task labels. The resulting label will be displayed as-is in
+        // the F4 Debug menu and will have "Debug: " prepended to the label when
+        // shown in the test gutter.
+        let label = if is_run {
+            resolved_label
+                .strip_prefix("run: ")
+                .unwrap_or(&resolved_label)
+                .to_string()
+        } else {
+            resolved_label
+                .strip_prefix("test: ")
+                .map(|suffix| format!("test {}", suffix))
+                .unwrap_or_else(|| resolved_label.clone())
+        };
 
         Some(DebugScenario {
             adapter: debug_adapter_name,

--- a/src/odin.rs
+++ b/src/odin.rs
@@ -458,7 +458,7 @@ impl zed::Extension for OdinExtension {
         // Create the build task template
         let build_template = BuildTaskTemplate {
             label: if is_test {
-                "odin debug test build".into()
+                "odin debug test".into()
             } else {
                 "odin debug build".into()
             },
@@ -475,7 +475,7 @@ impl zed::Extension for OdinExtension {
         let base_label = resolved_label
             .strip_prefix("run: ")
             .or_else(|| resolved_label.strip_prefix("test: "))
-            .unwrap_or(&resolved_label) // Both sides are now &str
+            .unwrap_or(&resolved_label)
             .to_string();
 
         // Add a special prefix to clarify debugging tests


### PR DESCRIPTION
This PR enhances the existing Odin Zed extension to support debugging tests so you can catch breakpoints in tests with ease. 

In most cases this creates two new debug tasks:
1. Debug test the current package
2. Debug test the closest test function in the current file

`#2` above also shows in the gutter next to the individual test functions as well. 

Example:

<img width="303" height="94" alt="image" src="https://github.com/user-attachments/assets/904f5236-67e9-40ea-83e2-47fc0c3ce3f5" />

<img width="545" height="187" alt="image" src="https://github.com/user-attachments/assets/14d2abc8-7e0c-474e-bf48-2b705f5fd8bc" />

