### PR TITLE
Add Vim mode text objects

### DIFF
--- a/languages/odin/textobjects.scm
+++ b/languages/odin/textobjects.scm
@@ -1,0 +1,20 @@
+; Procedures
+(procedure_declaration
+  (procedure
+    (block
+      "{"
+      (_)* @function.inside
+      "}"))) @function.around
+(overloaded_procedure_declaration) @function.around
+
+; Type declarations
+[
+  (struct_declaration)
+  (enum_declaration)
+  (union_declaration)
+  (bit_field_declaration)
+] @class.around
+
+; Comments
+(comment)+ @comment.around
+(block_comment) @comment.around

--- a/languages/odin/textobjects.scm
+++ b/languages/odin/textobjects.scm
@@ -5,6 +5,7 @@
       "{"
       (_)* @function.inside
       "}"))) @function.around
+
 (overloaded_procedure_declaration) @function.around
 
 ; Type declarations
@@ -17,4 +18,5 @@
 
 ; Comments
 (comment)+ @comment.around
+
 (block_comment) @comment.around


### PR DESCRIPTION
Added Vim mode text objects for procedures, type definitions and comments. For Vim commands like vaf, vif, dif etc.