### PR TITLE
fix: ignoring user-configured arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ This project provides Odin programming language support, featuring syntax highli
 
 ## Language Server
 
-This extension automatically updates to the latest OLS (Odin Language Server) monthly build on each startup.
+This extension automatically downloads the latest OLS (Odin Language Server) monthly build. To keep startup fast and avoid GitHub rate limits, it checks for updates at most once every 24 hours.
 
 ### Using a Custom OLS Binary
 
-If you want to use a specific OLS version or a locally built binary, you can override the automatic download:
+If you want to use a locally built binary, you can override the automatic download. `arguments` and `env` are passed to OLS whichever way the binary is resolved:
 
 ```json
 {
@@ -22,21 +22,42 @@ If you want to use a specific OLS version or a locally built binary, you can ove
     "ols": {
       "binary": {
         "path": "/path/to/your/ols",
-        "arguments": []
+        "arguments": [],
+        "env": {}
       }
     }
   }
 }
 ```
 
+### Pinning an OLS Release
+
+To pin a specific OLS release — or opt into the rolling nightly builds — set `release_tag` to any tag from the [OLS releases page](https://github.com/DanielGavin/ols/releases):
+
+```json
+{
+  "lsp": {
+    "ols": {
+      "settings": {
+        "release_tag": "dev-2026-06"
+      }
+    }
+  }
+}
+```
+
+Monthly tags (like `dev-2026-06`) are downloaded once and never re-checked. The special `nightly` tag is re-downloaded when a newer nightly build is available (checked at most once every 24 hours).
+
 ### Binary Resolution Order
 
 The extension searches for the OLS binary in the following priority order:
 
-1. **Custom binary path** - If configured in settings (see above)
-2. **System PATH** - Checks if `ols` is available in your system PATH
-3. **Cached binary** - Uses previously downloaded version if available
-4. **GitHub download** - Downloads latest release from [DanielGavin/ols](https://github.com/DanielGavin/ols/releases)
+1. **Custom binary path** - If configured in settings (see above), it is always used
+2. **System PATH** - Checks if `ols` is available in your system PATH (skipped when `release_tag` is set — an explicit pin outranks implicit PATH discovery)
+3. **Cached binary** - Uses a previously downloaded version if it matches the pinned tag, or if it is exactly the release found by a check less than 24 hours old
+4. **GitHub download** - Downloads the configured `release_tag` (or the latest release) from [DanielGavin/ols](https://github.com/DanielGavin/ols/releases)
+
+When GitHub is unreachable, the latest flow falls back to the newest intact download on disk. A pinned `release_tag` is only ever satisfied by that exact version — if its download is missing and GitHub is unreachable, the extension reports an error instead of silently running a different version.
 
 ---
 
@@ -74,6 +95,49 @@ Add OLS configuration directly in your Zed `settings.json`. This approach works 
 #### Use `ols.json` in Workspace Root
 
 Alternatively, create an `ols.json` file at the root of your workspace.For more configuration options, see the [OLS documentation](https://github.com/DanielGavin/ols#configuration).
+
+---
+
+## Formatting with odinfmt
+
+By default, formatting goes through OLS (`enable_format`, on by default). This works for most setups, but some issues — most commonly reported by **Vim mode** users (formatting glitches that persist regardless of OLS settings) — are only fixed by bypassing the language server and running [odinfmt](https://github.com/DanielGavin/ols) as an external formatter:
+
+```jsonc
+{
+  "languages": {
+    "Odin": {
+      "formatter": {
+        "external": {
+          "command": "odinfmt",
+          "arguments": ["-stdin"]
+        }
+      },
+      "format_on_save": "on"
+    }
+  }
+}
+```
+
+### You already have odinfmt
+
+Since OLS release `dev-2025-12`, the release zips bundle a prebuilt `odinfmt` executable — you don't need to build it yourself. Because this extension downloads those zips, odinfmt is already on your machine, next to the ols binary:
+
+| OS | Path |
+| --- | --- |
+| macOS | `~/Library/Application Support/Zed/extensions/work/odin/ols-<release>/odinfmt-<arch>-darwin` |
+| Linux | `~/.local/share/zed/extensions/work/odin/ols-<release>/odinfmt-<arch>-unknown-linux-gnu` |
+| Windows | `%LOCALAPPDATA%\Zed\extensions\work\odin\ols-<release>\odinfmt-x86_64-pc-windows-msvc.exe` |
+
+For example, on an Apple Silicon Mac running the `dev-2026-06` release, the `command` above would be:
+
+```
+~/Library/Application Support/Zed/extensions/work/odin/ols-dev-2026-06/odinfmt-arm64-darwin
+```
+
+> [!NOTE]
+> The folder name contains the release version, and old folders are deleted when the extension updates — so a hard-coded path breaks on the next monthly release. Either pin the version with `release_tag` (see above) so the path stays stable, or copy the binary somewhere permanent / onto your `PATH` and use plain `"command": "odinfmt"`.
+
+odinfmt reads its style options from an `odinfmt.json` in your project (e.g. `character_width`, `tabs`, `brace_style`, `sort_imports`) — see the [Odinfmt configurations](https://github.com/DanielGavin/ols#odinfmt-configurations).
 
 ---
 

--- a/src/logic.rs
+++ b/src/logic.rs
@@ -1,0 +1,194 @@
+pub const RELEASE_CHECK_INTERVAL_SECS: u64 = 24 * 60 * 60;
+pub const LAST_RELEASE_CHECK_FILE: &str = ".ols-last-release-check";
+pub const NIGHTLY_TAG: &str = "nightly";
+
+pub fn format_check_record(checked_at_secs: u64, version: &str) -> String {
+    format!("{checked_at_secs} {version}")
+}
+
+pub fn fresh_check_version(record: &str, now_secs: u64) -> Option<&str> {
+    let mut parts = record.split_whitespace();
+    let checked_at: u64 = parts.next()?.parse().ok()?;
+    let version = parts.next().filter(|v| !v.contains(['/', '\\']))?;
+    (now_secs.checked_sub(checked_at)? < RELEASE_CHECK_INTERVAL_SECS).then_some(version)
+}
+
+pub fn release_tag_from_settings(settings: Option<&serde_json::Value>) -> Option<String> {
+    settings?
+        .get("release_tag")?
+        .as_str()
+        .map(str::trim)
+        .filter(|tag| !tag.is_empty())
+        .map(str::to_string)
+}
+
+pub fn ols_version_dir(version: &str) -> String {
+    format!("ols-{version}")
+}
+
+pub fn reusable_version(
+    release_tag: Option<&str>,
+    check_record: Option<&str>,
+    now_secs: u64,
+) -> Option<String> {
+    let checked = || check_record.and_then(|record| fresh_check_version(record, now_secs));
+    match release_tag {
+        Some(tag) if tag != NIGHTLY_TAG => Some(tag.to_string()),
+        Some(_) => checked().filter(|v| *v == NIGHTLY_TAG).map(str::to_string),
+        None => checked().filter(|v| *v != NIGHTLY_TAG).map(str::to_string),
+    }
+}
+
+pub fn should_record_check(release_tag: Option<&str>) -> bool {
+    release_tag.is_none() || release_tag == Some(NIGHTLY_TAG)
+}
+
+pub fn must_replace_download(release_tag: Option<&str>) -> bool {
+    release_tag == Some(NIGHTLY_TAG)
+}
+
+pub fn use_path_binary(release_tag: Option<&str>) -> bool {
+    release_tag.is_none()
+}
+
+pub fn strip_extension_settings(settings: &mut serde_json::Value) {
+    if let Some(settings) = settings.as_object_mut() {
+        settings.remove("release_tag");
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Release {
+    pub version: String,
+    pub assets: Vec<ReleaseAsset>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ReleaseAsset {
+    pub name: String,
+    pub download_url: String,
+}
+
+pub trait Host {
+    fn is_file(&self, path: &str) -> bool;
+    fn list_ols_dirs(&self) -> Vec<String>;
+    fn fetch_release(&mut self, tag: Option<&str>) -> Result<Release, String>;
+    fn download_and_install(
+        &mut self,
+        download_url: &str,
+        version_dir: &str,
+        binary_path: &str,
+    ) -> Result<(), String>;
+    fn remove_dir(&mut self, dir: &str);
+    fn write_check_record(&mut self, contents: &str);
+    fn set_status_checking(&mut self);
+    fn set_status_downloading(&mut self);
+}
+
+pub struct ResolveInputs<'a> {
+    pub cached_binary_path: Option<&'a str>,
+    pub release_tag: Option<&'a str>,
+    pub check_record: Option<&'a str>,
+    pub now_secs: Option<u64>,
+    pub asset_stem: &'a str,
+    pub executable_name: &'a str,
+    pub separator: &'a str,
+}
+
+impl ResolveInputs<'_> {
+    fn binary_path_in(&self, dir: &str) -> String {
+        format!("{dir}{}{}", self.separator, self.executable_name)
+    }
+}
+
+pub fn resolve_ols_binary(host: &mut dyn Host, inputs: &ResolveInputs) -> Result<String, String> {
+    if let Some(path) = inputs.cached_binary_path.filter(|path| host.is_file(path)) {
+        return Ok(path.to_string());
+    }
+
+    let now = inputs.now_secs.unwrap_or(0);
+    if let Some(version) = reusable_version(inputs.release_tag, inputs.check_record, now) {
+        let path = inputs.binary_path_in(&ols_version_dir(&version));
+        if host.is_file(&path) {
+            return Ok(path);
+        }
+    }
+
+    host.set_status_checking();
+    let release = match host.fetch_release(inputs.release_tag) {
+        Ok(release) => release,
+        Err(error) => {
+            return offline_fallback(host, inputs)
+                .ok_or_else(|| fetch_failed_message(inputs.release_tag, &error));
+        }
+    };
+
+    let asset_name = format!("{}.zip", inputs.asset_stem);
+    let asset = release
+        .assets
+        .iter()
+        .find(|asset| asset.name == asset_name)
+        .ok_or_else(|| format!("no asset found matching {asset_name:?}"))?;
+
+    let version_dir = ols_version_dir(&release.version);
+    let binary_path = inputs.binary_path_in(&version_dir);
+
+    if must_replace_download(inputs.release_tag) {
+        host.remove_dir(&version_dir);
+    }
+    if !host.is_file(&binary_path) {
+        host.set_status_downloading();
+        host.download_and_install(&asset.download_url, &version_dir, &binary_path)?;
+        if !host.is_file(&binary_path) {
+            return Err(format!(
+                "downloaded OLS release {} but it did not contain {:?}",
+                release.version, binary_path
+            ));
+        }
+    }
+
+    for dir in host.list_ols_dirs() {
+        if dir != version_dir {
+            host.remove_dir(&dir);
+        }
+    }
+    if should_record_check(inputs.release_tag) {
+        if let Some(now) = inputs.now_secs {
+            host.write_check_record(&format_check_record(now, &release.version));
+        }
+    }
+    Ok(binary_path)
+}
+
+fn offline_fallback(host: &dyn Host, inputs: &ResolveInputs) -> Option<String> {
+    match inputs.release_tag {
+        Some(pinned_tag) => {
+            let path = inputs.binary_path_in(&ols_version_dir(pinned_tag));
+            host.is_file(&path).then_some(path)
+        }
+        None => newest_existing_binary(host, inputs),
+    }
+}
+
+fn newest_existing_binary(host: &dyn Host, inputs: &ResolveInputs) -> Option<String> {
+    let mut dirs = host.list_ols_dirs();
+    dirs.sort();
+    dirs.into_iter().rev().find_map(|dir| {
+        let path = inputs.binary_path_in(&dir);
+        host.is_file(&path).then_some(path)
+    })
+}
+
+fn fetch_failed_message(release_tag: Option<&str>, error: &str) -> String {
+    match release_tag {
+        Some(tag) => format!(
+            "Failed to download OLS release {tag:?}: {error}\n\n\
+            OLS release tags look like \"dev-2026-06\" or \"nightly\"; check the \
+            `release_tag` in your `lsp.ols.settings` and your internet connection.",
+        ),
+        None => format!(
+            "Failed to download OLS language server: {error}\n\n\
+            To resolve this issue, you can connect to the internet and restart Zed or Manually install OLS.",
+        ),
+    }
+}

--- a/src/odin.rs
+++ b/src/odin.rs
@@ -13,8 +13,19 @@ use zed_extension_api::{
 };
 
 struct OdinExtension {
-    cached_binary_path: Option<String>,
+    cached_binary: Option<CachedBinary>,
 }
+
+struct CachedBinary {
+    release_tag: Option<String>,
+    path: String,
+}
+
+mod logic;
+use logic::{
+    release_tag_from_settings, resolve_ols_binary, strip_extension_settings, use_path_binary, Host,
+    Release, ReleaseAsset, ResolveInputs, LAST_RELEASE_CHECK_FILE,
+};
 
 const GITHUB_REPO: &str = "DanielGavin/ols";
 
@@ -52,26 +63,11 @@ impl OdinExtension {
         Some(binary_name)
     }
 
-    fn find_existing_ols_binary(&self) -> Option<String> {
-        let entries = fs::read_dir(".").ok()?;
-        let (platform, arch) = zed::current_platform();
-        let binary_name = self.ols_binary_name(platform, arch)?;
-        let executable_name = format!("{}{}", binary_name, Self::exe_suffix(platform));
-        let separator = Self::path_separator(platform);
-
-        for entry in entries.flatten() {
-            let file_name = entry.file_name();
-            let name_str = file_name.to_str()?;
-            if name_str.starts_with("ols-") && entry.path().is_dir() {
-                let binary_path = entry.path().join(&executable_name);
-                if binary_path.is_file() {
-                    let full_path = format!("{}{}{}", name_str, separator, executable_name);
-                    return Some(full_path);
-                }
-            }
-        }
-
-        None
+    fn unix_time_now() -> Option<u64> {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .ok()
+            .map(|duration| duration.as_secs())
     }
 
     fn language_server_binary_path(
@@ -79,102 +75,134 @@ impl OdinExtension {
         language_server_id: &LanguageServerId,
         worktree: &Worktree,
     ) -> Result<String> {
-        let language_server = language_server_id.as_ref();
-        if let Some(path) = LspSettings::for_worktree(language_server, worktree)
-            .ok()
-            .and_then(|settings| settings.binary)
-            .and_then(|binary| binary.path)
+        let lsp_settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree).ok();
+
+        if let Some(path) = lsp_settings
+            .as_ref()
+            .and_then(|settings| settings.binary.as_ref())
+            .and_then(|binary| binary.path.clone())
         {
             return Ok(path);
         }
 
-        if let Some(path) = worktree.which(language_server) {
-            return Ok(path);
-        }
+        let release_tag =
+            release_tag_from_settings(lsp_settings.as_ref().and_then(|s| s.settings.as_ref()));
 
-        if let Some(path) = &self.cached_binary_path {
-            if fs::metadata(path).is_ok_and(|stat| stat.is_file()) {
-                return Ok(path.to_string());
+        if use_path_binary(release_tag.as_deref()) {
+            if let Some(path) = worktree.which(language_server_id.as_ref()) {
+                return Ok(path);
             }
         }
-
-        zed::set_language_server_installation_status(
-            language_server_id,
-            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
-        );
-
-        let release = match zed::latest_github_release(
-            GITHUB_REPO,
-            zed::GithubReleaseOptions {
-                require_assets: true,
-                pre_release: false,
-            },
-        ) {
-            Ok(release) => release,
-            Err(e) => {
-                if let Some(path) = self.find_existing_ols_binary() {
-                    self.cached_binary_path = Some(path.clone());
-                    return Ok(path);
-                }
-
-                return Err(format!(
-                    "Failed to download OLS language server: {}\n\n\
-                    To resolve this issue, you can connect to the internet and restart Zed or Manually install OLS.",
-                    e
-                ));
-            }
-        };
 
         let (platform, arch) = zed::current_platform();
-        let file_name = self
+        let asset_stem = self
             .ols_binary_name(platform, arch)
             .ok_or_else(|| format!("Unsupported platform {:?}", arch))?;
-        let asset_name = format!("{}.zip", file_name);
+        let executable_name = format!("{}{}", asset_stem, Self::exe_suffix(platform));
+        let check_record = fs::read_to_string(LAST_RELEASE_CHECK_FILE).ok();
 
-        let asset = release
-            .assets
-            .iter()
-            .find(|asset| asset.name == asset_name)
-            .ok_or_else(|| format!("no asset found matching {:?}", asset_name))?;
+        let cached_binary_path = self
+            .cached_binary
+            .as_ref()
+            .filter(|cached| cached.release_tag.as_deref() == release_tag.as_deref())
+            .map(|cached| cached.path.clone());
 
-        let version_dir = format!("ols-{}", release.version);
-        let separator = Self::path_separator(platform);
-        let binary_path = format!(
-            "{}{}{}{}",
-            version_dir,
-            separator,
-            file_name,
-            Self::exe_suffix(platform)
-        );
+        let inputs = ResolveInputs {
+            cached_binary_path: cached_binary_path.as_deref(),
+            release_tag: release_tag.as_deref(),
+            check_record: check_record.as_deref(),
+            now_secs: Self::unix_time_now(),
+            asset_stem: &asset_stem,
+            executable_name: &executable_name,
+            separator: Self::path_separator(platform),
+        };
 
-        if !fs::metadata(&binary_path).is_ok_and(|stat| stat.is_file()) {
-            zed::set_language_server_installation_status(
-                language_server_id,
-                &zed::LanguageServerInstallationStatus::Downloading,
-            );
+        let mut host = ZedHost { language_server_id };
+        let path = resolve_ols_binary(&mut host, &inputs)?;
+        self.cached_binary = Some(CachedBinary {
+            release_tag,
+            path: path.clone(),
+        });
+        Ok(path)
+    }
+}
 
-            zed::download_file(
-                &asset.download_url,
-                &version_dir,
-                zed::DownloadedFileType::Zip,
-            )
+struct ZedHost<'a> {
+    language_server_id: &'a LanguageServerId,
+}
+
+impl Host for ZedHost<'_> {
+    fn is_file(&self, path: &str) -> bool {
+        fs::metadata(path).is_ok_and(|stat| stat.is_file())
+    }
+
+    fn list_ols_dirs(&self) -> Vec<String> {
+        let Ok(entries) = fs::read_dir(".") else {
+            return Vec::new();
+        };
+        entries
+            .flatten()
+            .filter(|entry| entry.path().is_dir())
+            .filter_map(|entry| entry.file_name().to_str().map(str::to_string))
+            .filter(|name| name.starts_with("ols-"))
+            .collect()
+    }
+
+    fn fetch_release(&mut self, tag: Option<&str>) -> Result<Release, String> {
+        let release = match tag {
+            Some(tag) => zed::github_release_by_tag_name(GITHUB_REPO, tag),
+            None => zed::latest_github_release(
+                GITHUB_REPO,
+                zed::GithubReleaseOptions {
+                    require_assets: true,
+                    pre_release: false,
+                },
+            ),
+        }?;
+        Ok(Release {
+            version: release.version,
+            assets: release
+                .assets
+                .into_iter()
+                .map(|asset| ReleaseAsset {
+                    name: asset.name,
+                    download_url: asset.download_url,
+                })
+                .collect(),
+        })
+    }
+
+    fn download_and_install(
+        &mut self,
+        download_url: &str,
+        version_dir: &str,
+        binary_path: &str,
+    ) -> Result<(), String> {
+        zed::download_file(download_url, version_dir, zed::DownloadedFileType::Zip)
             .map_err(|e| format!("failed to download file: {e}"))?;
+        zed::make_file_executable(binary_path)
+    }
 
-            zed::make_file_executable(&binary_path)?;
+    fn remove_dir(&mut self, dir: &str) {
+        fs::remove_dir_all(dir).ok();
+    }
 
-            // Cleanup older versions
-            let entries =
-                fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
-            for entry in entries {
-                let entry = entry.map_err(|e| format!("failed to load directory entry {e}"))?;
-                if entry.file_name().to_str() != Some(&version_dir) {
-                    fs::remove_dir_all(entry.path()).ok();
-                }
-            }
-        }
+    fn write_check_record(&mut self, contents: &str) {
+        fs::write(LAST_RELEASE_CHECK_FILE, contents).ok();
+    }
 
-        self.cached_binary_path = Some(binary_path.clone());
-        Ok(binary_path)
+    fn set_status_checking(&mut self) {
+        zed::set_language_server_installation_status(
+            self.language_server_id,
+            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
+        );
+    }
+
+    fn set_status_downloading(&mut self) {
+        zed::set_language_server_installation_status(
+            self.language_server_id,
+            &zed::LanguageServerInstallationStatus::Downloading,
+        );
     }
 }
 
@@ -222,7 +250,7 @@ impl OdinExtension {
 impl zed::Extension for OdinExtension {
     fn new() -> Self {
         Self {
-            cached_binary_path: None,
+            cached_binary: None,
         }
     }
 
@@ -231,11 +259,23 @@ impl zed::Extension for OdinExtension {
         language_server_id: &LanguageServerId,
         worktree: &Worktree,
     ) -> Result<zed::Command> {
+        let binary_settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|settings| settings.binary);
+        let args = binary_settings
+            .as_ref()
+            .and_then(|binary| binary.arguments.clone())
+            .unwrap_or_default();
+        let env = binary_settings
+            .and_then(|binary| binary.env)
+            .map(|env| env.into_iter().collect())
+            .unwrap_or_default();
+
         let ols_binary_path = self.language_server_binary_path(language_server_id, worktree)?;
         Ok(zed::Command {
             command: ols_binary_path,
-            args: Default::default(),
-            env: Default::default(),
+            args,
+            env,
         })
     }
 
@@ -255,10 +295,11 @@ impl zed::Extension for OdinExtension {
         language_server_id: &LanguageServerId,
         worktree: &Worktree,
     ) -> Result<Option<serde_json::Value>> {
-        let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)
+        let mut settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)
             .ok()
             .and_then(|lsp_settings| lsp_settings.settings.clone())
             .unwrap_or_default();
+        strip_extension_settings(&mut settings);
         Ok(Some(settings))
     }
 

--- a/tests/logic.rs
+++ b/tests/logic.rs
@@ -1,0 +1,581 @@
+#[allow(dead_code)]
+#[path = "../src/logic.rs"]
+mod logic;
+
+use logic::*;
+use std::collections::BTreeSet;
+
+const NOW: u64 = 1_800_000_000;
+const EXE: &str = "ols-arm64-darwin";
+
+fn record(age_secs: u64, version: &str) -> String {
+    format_check_record(NOW - age_secs, version)
+}
+
+#[test]
+fn check_version_returned_within_interval() {
+    assert_eq!(
+        fresh_check_version(&record(0, "dev-2026-06"), NOW),
+        Some("dev-2026-06")
+    );
+    assert_eq!(
+        fresh_check_version(&record(RELEASE_CHECK_INTERVAL_SECS - 1, "nightly"), NOW),
+        Some("nightly")
+    );
+    assert_eq!(
+        fresh_check_version(&format!("{}\n", record(60, "dev-2026-06")), NOW),
+        Some("dev-2026-06")
+    );
+}
+
+#[test]
+fn check_is_stale_at_or_past_interval() {
+    assert_eq!(
+        fresh_check_version(&record(RELEASE_CHECK_INTERVAL_SECS, "dev-2026-06"), NOW),
+        None
+    );
+    assert_eq!(fresh_check_version("0 dev-2026-06", NOW), None);
+}
+
+#[test]
+fn check_is_stale_for_invalid_or_future_records() {
+    assert_eq!(fresh_check_version("", NOW), None);
+    assert_eq!(fresh_check_version("not-a-number dev-2026-06", NOW), None);
+    assert_eq!(fresh_check_version("99999999999999999999999 x", NOW), None);
+    assert_eq!(fresh_check_version(&NOW.to_string(), NOW), None);
+    assert_eq!(
+        fresh_check_version(&format_check_record(NOW + 60, "dev-2026-06"), NOW),
+        None
+    );
+}
+
+#[test]
+fn version_dir_matches_tag_and_release_version() {
+    assert_eq!(ols_version_dir("dev-2026-06"), "ols-dev-2026-06");
+    assert_eq!(ols_version_dir(NIGHTLY_TAG), "ols-nightly");
+}
+
+#[test]
+fn reusable_version_rules() {
+    assert_eq!(
+        reusable_version(Some("dev-2026-05"), None, NOW).as_deref(),
+        Some("dev-2026-05")
+    );
+    assert_eq!(
+        reusable_version(Some("dev-2026-05"), Some(&record(60, "dev-2026-06")), NOW).as_deref(),
+        Some("dev-2026-05")
+    );
+    assert_eq!(
+        reusable_version(None, Some(&record(60, "dev-2026-06")), NOW).as_deref(),
+        Some("dev-2026-06")
+    );
+    assert_eq!(reusable_version(None, None, NOW), None);
+    assert_eq!(
+        reusable_version(
+            None,
+            Some(&record(RELEASE_CHECK_INTERVAL_SECS, "dev-2026-06")),
+            NOW
+        ),
+        None
+    );
+    assert_eq!(
+        reusable_version(None, Some(&record(60, NIGHTLY_TAG)), NOW),
+        None
+    );
+    assert_eq!(
+        reusable_version(Some(NIGHTLY_TAG), Some(&record(60, NIGHTLY_TAG)), NOW).as_deref(),
+        Some(NIGHTLY_TAG)
+    );
+    assert_eq!(
+        reusable_version(
+            Some(NIGHTLY_TAG),
+            Some(&record(RELEASE_CHECK_INTERVAL_SECS, NIGHTLY_TAG)),
+            NOW
+        ),
+        None
+    );
+    assert_eq!(
+        reusable_version(Some(NIGHTLY_TAG), Some(&record(60, "dev-2026-06")), NOW),
+        None
+    );
+}
+
+#[test]
+fn recording_and_replacement_rules() {
+    assert!(!should_record_check(Some("dev-2026-05")));
+    assert!(should_record_check(None));
+    assert!(should_record_check(Some(NIGHTLY_TAG)));
+    assert!(must_replace_download(Some(NIGHTLY_TAG)));
+    assert!(!must_replace_download(Some("dev-2026-06")));
+    assert!(!must_replace_download(None));
+}
+
+#[test]
+fn path_binary_is_outranked_by_explicit_pin() {
+    assert!(use_path_binary(None));
+    assert!(!use_path_binary(Some("dev-2026-06")));
+    assert!(!use_path_binary(Some(NIGHTLY_TAG)));
+}
+
+#[test]
+fn strip_extension_settings_removes_only_release_tag() {
+    let mut settings = serde_json::json!({
+        "release_tag": "nightly",
+        "odin_command": "/usr/local/bin/odin",
+    });
+    strip_extension_settings(&mut settings);
+    assert_eq!(
+        settings,
+        serde_json::json!({ "odin_command": "/usr/local/bin/odin" })
+    );
+}
+
+#[test]
+fn strip_extension_settings_ignores_non_objects() {
+    for mut settings in [
+        serde_json::Value::Null,
+        serde_json::json!("nightly"),
+        serde_json::json!([1, 2, 3]),
+    ] {
+        let before = settings.clone();
+        strip_extension_settings(&mut settings);
+        assert_eq!(settings, before);
+    }
+}
+
+#[derive(Default)]
+struct FakeHost {
+    files: BTreeSet<String>,
+    dirs: BTreeSet<String>,
+    release: Option<Release>,
+    download_error: Option<String>,
+    download_produces_nothing: bool,
+    fetched_tags: Vec<Option<String>>,
+    downloaded_urls: Vec<String>,
+    removed_dirs: Vec<String>,
+    written_record: Option<String>,
+    statuses: Vec<&'static str>,
+}
+
+impl FakeHost {
+    fn with_release(version: &str) -> Self {
+        FakeHost {
+            release: Some(release(version)),
+            ..FakeHost::default()
+        }
+    }
+
+    fn add_download(&mut self, version: &str) {
+        let dir = ols_version_dir(version);
+        self.files.insert(format!("{dir}/{EXE}"));
+        self.dirs.insert(dir);
+    }
+
+    fn fetch_count(&self) -> usize {
+        self.fetched_tags.len()
+    }
+}
+
+fn release(version: &str) -> Release {
+    Release {
+        version: version.to_string(),
+        assets: vec![ReleaseAsset {
+            name: format!("{EXE}.zip"),
+            download_url: format!("https://example.com/{version}/{EXE}.zip"),
+        }],
+    }
+}
+
+impl Host for FakeHost {
+    fn is_file(&self, path: &str) -> bool {
+        self.files.contains(path)
+    }
+
+    fn list_ols_dirs(&self) -> Vec<String> {
+        self.dirs.iter().cloned().collect()
+    }
+
+    fn fetch_release(&mut self, tag: Option<&str>) -> Result<Release, String> {
+        self.fetched_tags.push(tag.map(str::to_string));
+        self.release
+            .clone()
+            .ok_or_else(|| "network down".to_string())
+    }
+
+    fn download_and_install(
+        &mut self,
+        download_url: &str,
+        version_dir: &str,
+        binary_path: &str,
+    ) -> Result<(), String> {
+        self.downloaded_urls.push(download_url.to_string());
+        if let Some(error) = &self.download_error {
+            return Err(error.clone());
+        }
+        self.dirs.insert(version_dir.to_string());
+        if !self.download_produces_nothing {
+            self.files.insert(binary_path.to_string());
+        }
+        Ok(())
+    }
+
+    fn remove_dir(&mut self, dir: &str) {
+        self.removed_dirs.push(dir.to_string());
+        self.dirs.remove(dir);
+        let prefix = format!("{dir}/");
+        self.files.retain(|file| !file.starts_with(&prefix));
+    }
+
+    fn write_check_record(&mut self, contents: &str) {
+        self.written_record = Some(contents.to_string());
+    }
+
+    fn set_status_checking(&mut self) {
+        self.statuses.push("checking");
+    }
+
+    fn set_status_downloading(&mut self) {
+        self.statuses.push("downloading");
+    }
+}
+
+fn inputs<'a>(release_tag: Option<&'a str>, check_record: Option<&'a str>) -> ResolveInputs<'a> {
+    ResolveInputs {
+        cached_binary_path: None,
+        release_tag,
+        check_record,
+        now_secs: Some(NOW),
+        asset_stem: EXE,
+        executable_name: EXE,
+        separator: "/",
+    }
+}
+
+#[test]
+fn cached_path_reused_only_while_its_file_exists() {
+    let mut host = FakeHost::with_release("dev-2026-06");
+    host.add_download("dev-2026-05");
+    let cached = format!("ols-dev-2026-05/{EXE}");
+
+    let mut req = inputs(None, None);
+    req.cached_binary_path = Some(&cached);
+    assert_eq!(resolve_ols_binary(&mut host, &req), Ok(cached.clone()));
+    assert_eq!(host.fetch_count(), 0);
+    assert!(host.statuses.is_empty());
+
+    host.remove_dir("ols-dev-2026-05");
+    host.removed_dirs.clear();
+    let resolved = resolve_ols_binary(&mut host, &req).unwrap();
+    assert_eq!(resolved, format!("ols-dev-2026-06/{EXE}"));
+    assert_eq!(host.fetch_count(), 1);
+}
+
+#[test]
+fn pinned_monthly_uses_existing_download_without_network() {
+    let mut host = FakeHost::default();
+    host.add_download("dev-2026-05");
+
+    let resolved = resolve_ols_binary(&mut host, &inputs(Some("dev-2026-05"), None)).unwrap();
+    assert_eq!(resolved, format!("ols-dev-2026-05/{EXE}"));
+    assert_eq!(host.fetch_count(), 0);
+    assert_eq!(host.written_record, None);
+}
+
+#[test]
+fn pinned_monthly_downloads_when_missing_and_writes_no_record() {
+    let mut host = FakeHost::with_release("dev-2026-05");
+    host.add_download("dev-2026-06");
+
+    let resolved = resolve_ols_binary(&mut host, &inputs(Some("dev-2026-05"), None)).unwrap();
+    assert_eq!(resolved, format!("ols-dev-2026-05/{EXE}"));
+    assert_eq!(host.fetched_tags, vec![Some("dev-2026-05".to_string())]);
+    assert_eq!(host.statuses, vec!["checking", "downloading"]);
+    assert_eq!(host.removed_dirs, vec!["ols-dev-2026-06"]);
+    assert_eq!(host.written_record, None);
+}
+
+#[test]
+fn pinned_monthly_recovers_when_user_empties_the_directory() {
+    let mut host = FakeHost::with_release("dev-2026-05");
+    host.dirs.insert("ols-dev-2026-05".to_string());
+
+    let resolved = resolve_ols_binary(&mut host, &inputs(Some("dev-2026-05"), None)).unwrap();
+    assert_eq!(resolved, format!("ols-dev-2026-05/{EXE}"));
+    assert_eq!(host.downloaded_urls.len(), 1);
+}
+
+#[test]
+fn latest_with_fresh_record_reuses_exactly_the_recorded_release() {
+    let mut host = FakeHost::default();
+    host.add_download("dev-2026-05");
+    host.add_download("dev-2026-06");
+
+    let fresh = record(60, "dev-2026-06");
+    let resolved = resolve_ols_binary(&mut host, &inputs(None, Some(&fresh))).unwrap();
+    assert_eq!(resolved, format!("ols-dev-2026-06/{EXE}"));
+    assert_eq!(host.fetch_count(), 0);
+}
+
+#[test]
+fn latest_recovers_when_recorded_download_was_deleted() {
+    let mut host = FakeHost::with_release("dev-2026-06");
+    let fresh = record(60, "dev-2026-06");
+
+    let resolved = resolve_ols_binary(&mut host, &inputs(None, Some(&fresh))).unwrap();
+    assert_eq!(resolved, format!("ols-dev-2026-06/{EXE}"));
+    assert_eq!(host.fetch_count(), 1);
+    assert_eq!(host.written_record, Some(record(0, "dev-2026-06")));
+}
+
+#[test]
+fn latest_with_stale_or_tampered_record_checks_github() {
+    for bad_record in [
+        None,
+        Some(record(RELEASE_CHECK_INTERVAL_SECS, "dev-2026-06")),
+        Some("garbage".to_string()),
+        Some(NOW.to_string()),
+        Some(format_check_record(NOW + 999, "dev-2026-06")),
+    ] {
+        let mut host = FakeHost::with_release("dev-2026-06");
+        host.add_download("dev-2026-05");
+
+        let resolved = resolve_ols_binary(&mut host, &inputs(None, bad_record.as_deref())).unwrap();
+        assert_eq!(resolved, format!("ols-dev-2026-06/{EXE}"));
+        assert_eq!(host.fetch_count(), 1, "record {bad_record:?} was trusted");
+        assert_eq!(host.written_record, Some(record(0, "dev-2026-06")));
+        assert!(host.removed_dirs.contains(&"ols-dev-2026-05".to_string()));
+    }
+}
+
+#[test]
+fn latest_skips_download_when_release_already_on_disk() {
+    let mut host = FakeHost::with_release("dev-2026-06");
+    host.add_download("dev-2026-06");
+
+    let resolved = resolve_ols_binary(&mut host, &inputs(None, None)).unwrap();
+    assert_eq!(resolved, format!("ols-dev-2026-06/{EXE}"));
+    assert_eq!(host.fetch_count(), 1);
+    assert!(host.downloaded_urls.is_empty());
+    assert_eq!(host.statuses, vec!["checking"]);
+    assert_eq!(host.written_record, Some(record(0, "dev-2026-06")));
+}
+
+#[test]
+fn nightly_fresh_is_reused_and_stale_is_replaced() {
+    let mut host = FakeHost::default();
+    host.add_download(NIGHTLY_TAG);
+    let fresh = record(60, NIGHTLY_TAG);
+    let resolved = resolve_ols_binary(&mut host, &inputs(Some(NIGHTLY_TAG), Some(&fresh))).unwrap();
+    assert_eq!(resolved, format!("ols-nightly/{EXE}"));
+    assert_eq!(host.fetch_count(), 0);
+
+    let mut host = FakeHost::with_release(NIGHTLY_TAG);
+    host.add_download(NIGHTLY_TAG);
+    let stale = record(RELEASE_CHECK_INTERVAL_SECS, NIGHTLY_TAG);
+    let resolved = resolve_ols_binary(&mut host, &inputs(Some(NIGHTLY_TAG), Some(&stale))).unwrap();
+    assert_eq!(resolved, format!("ols-nightly/{EXE}"));
+    assert_eq!(host.fetched_tags, vec![Some(NIGHTLY_TAG.to_string())]);
+    assert!(host.removed_dirs.contains(&"ols-nightly".to_string()));
+    assert_eq!(host.downloaded_urls.len(), 1);
+    assert_eq!(host.written_record, Some(record(0, NIGHTLY_TAG)));
+}
+
+#[test]
+fn fetch_failure_falls_back_to_newest_intact_download() {
+    let mut host = FakeHost::default();
+    host.add_download("dev-2026-05");
+    host.add_download("dev-2026-06");
+
+    let resolved = resolve_ols_binary(&mut host, &inputs(None, None)).unwrap();
+    assert_eq!(resolved, format!("ols-dev-2026-06/{EXE}"));
+
+    let mut host = FakeHost::default();
+    host.add_download("dev-2026-05");
+    host.dirs.insert("ols-dev-2026-06".to_string());
+
+    let resolved = resolve_ols_binary(&mut host, &inputs(None, None)).unwrap();
+    assert_eq!(resolved, format!("ols-dev-2026-05/{EXE}"));
+}
+
+#[test]
+fn fetch_failure_with_nothing_usable_errors_helpfully() {
+    let mut host = FakeHost::default();
+    let err = resolve_ols_binary(&mut host, &inputs(None, None)).unwrap_err();
+    assert!(err.contains("Failed to download OLS language server"));
+
+    let mut host = FakeHost::default();
+    let err = resolve_ols_binary(&mut host, &inputs(Some("dev-9999-99"), None)).unwrap_err();
+    assert!(err.contains("dev-9999-99"));
+    assert!(err.contains("release_tag"));
+
+    let mut host = FakeHost::default();
+    host.dirs.insert("ols-dev-2026-06".to_string());
+    assert!(resolve_ols_binary(&mut host, &inputs(None, None)).is_err());
+}
+
+#[test]
+fn offline_pin_is_never_satisfied_by_a_different_version() {
+    let mut host = FakeHost::default();
+    host.add_download("dev-2026-06");
+
+    let err = resolve_ols_binary(&mut host, &inputs(Some("dev-2026-05"), None)).unwrap_err();
+    assert!(err.contains("dev-2026-05"));
+
+    let mut host = FakeHost::default();
+    host.add_download(NIGHTLY_TAG);
+    host.add_download("dev-2026-06");
+    let stale = record(RELEASE_CHECK_INTERVAL_SECS, NIGHTLY_TAG);
+    let resolved = resolve_ols_binary(&mut host, &inputs(Some(NIGHTLY_TAG), Some(&stale))).unwrap();
+    assert_eq!(resolved, format!("ols-nightly/{EXE}"));
+}
+
+#[test]
+fn tampered_record_cannot_point_outside_the_work_dir() {
+    assert_eq!(
+        fresh_check_version(&record(60, "../../../usr/bin/evil"), NOW),
+        None
+    );
+    assert_eq!(fresh_check_version(&record(60, "..\\evil"), NOW), None);
+}
+
+#[test]
+fn release_tag_setting_is_validated() {
+    let tag = |json: serde_json::Value| release_tag_from_settings(Some(&json));
+
+    assert_eq!(
+        tag(serde_json::json!({"release_tag": "dev-2026-06"})).as_deref(),
+        Some("dev-2026-06")
+    );
+    assert_eq!(
+        tag(serde_json::json!({"release_tag": "  nightly  "})).as_deref(),
+        Some("nightly")
+    );
+    assert_eq!(tag(serde_json::json!({"release_tag": ""})), None);
+    assert_eq!(tag(serde_json::json!({"release_tag": "   "})), None);
+    assert_eq!(tag(serde_json::json!({"release_tag": 42})), None);
+    assert_eq!(tag(serde_json::json!({"release_tag": null})), None);
+    assert_eq!(tag(serde_json::json!({})), None);
+    assert_eq!(release_tag_from_settings(None), None);
+}
+
+#[test]
+fn download_failure_propagates_and_leaves_no_record() {
+    let mut host = FakeHost::with_release("dev-2026-06");
+    host.download_error = Some("failed to download file: connection reset".to_string());
+
+    let err = resolve_ols_binary(&mut host, &inputs(None, None)).unwrap_err();
+    assert!(err.contains("connection reset"));
+    assert_eq!(host.written_record, None);
+}
+
+#[test]
+fn download_that_yields_no_binary_is_rejected() {
+    let mut host = FakeHost::with_release("dev-2026-06");
+    host.download_produces_nothing = true;
+
+    let err = resolve_ols_binary(&mut host, &inputs(None, None)).unwrap_err();
+    assert!(err.contains("did not contain"));
+    assert_eq!(host.written_record, None);
+}
+
+#[test]
+fn release_without_matching_asset_errors() {
+    let mut host = FakeHost::default();
+    host.release = Some(Release {
+        version: "dev-2026-06".to_string(),
+        assets: vec![ReleaseAsset {
+            name: "ols-source-only.tar.gz".to_string(),
+            download_url: "https://example.com/src.tar.gz".to_string(),
+        }],
+    });
+
+    let err = resolve_ols_binary(&mut host, &inputs(None, None)).unwrap_err();
+    assert!(err.contains("no asset found"));
+}
+
+#[test]
+fn clock_unavailable_still_resolves_but_never_records() {
+    let mut host = FakeHost::with_release("dev-2026-06");
+    let fresh = record(60, "dev-2026-06");
+    let mut req = inputs(None, Some(&fresh));
+    req.now_secs = None;
+
+    let resolved = resolve_ols_binary(&mut host, &req).unwrap();
+    assert_eq!(resolved, format!("ols-dev-2026-06/{EXE}"));
+    assert_eq!(host.fetch_count(), 1);
+    assert_eq!(host.written_record, None);
+}
+
+#[test]
+fn pin_unpin_replay_never_serves_the_pinned_version() {
+    let mut host = FakeHost::with_release("dev-2026-06");
+
+    let resolved = resolve_ols_binary(&mut host, &inputs(None, None)).unwrap();
+    assert_eq!(resolved, format!("ols-dev-2026-06/{EXE}"));
+    let record_after_latest = host.written_record.clone().unwrap();
+
+    host.release = Some(release("dev-2026-05"));
+    let resolved = resolve_ols_binary(
+        &mut host,
+        &inputs(Some("dev-2026-05"), Some(&record_after_latest)),
+    )
+    .unwrap();
+    assert_eq!(resolved, format!("ols-dev-2026-05/{EXE}"));
+    assert_eq!(host.written_record, Some(record_after_latest.clone()));
+
+    host.release = Some(release("dev-2026-06"));
+    let resolved =
+        resolve_ols_binary(&mut host, &inputs(None, Some(&record_after_latest))).unwrap();
+    assert_eq!(resolved, format!("ols-dev-2026-06/{EXE}"));
+    assert_eq!(host.list_ols_dirs(), vec!["ols-dev-2026-06".to_string()]);
+
+    let latest_record = host.written_record.clone().unwrap();
+    let fetches_before = host.fetch_count();
+    let resolved = resolve_ols_binary(&mut host, &inputs(None, Some(&latest_record))).unwrap();
+    assert_eq!(resolved, format!("ols-dev-2026-06/{EXE}"));
+    assert_eq!(host.fetch_count(), fetches_before);
+}
+
+#[test]
+fn windows_inputs_produce_backslash_paths_with_exe_suffix() {
+    let stem = "ols-x86_64-pc-windows-msvc";
+    let mut host = FakeHost::default();
+    host.release = Some(Release {
+        version: "dev-2026-06".to_string(),
+        assets: vec![ReleaseAsset {
+            name: format!("{stem}.zip"),
+            download_url: format!("https://example.com/{stem}.zip"),
+        }],
+    });
+    let req = ResolveInputs {
+        cached_binary_path: None,
+        release_tag: None,
+        check_record: None,
+        now_secs: Some(NOW),
+        asset_stem: stem,
+        executable_name: &format!("{stem}.exe"),
+        separator: "\\",
+    };
+
+    let resolved = resolve_ols_binary(&mut host, &req).unwrap();
+    assert_eq!(resolved, format!("ols-dev-2026-06\\{stem}.exe"));
+    assert_eq!(host.written_record, Some(record(0, "dev-2026-06")));
+
+    let resolved_again = resolve_ols_binary(&mut host, &req).unwrap();
+    assert_eq!(resolved_again, resolved);
+    assert_eq!(host.downloaded_urls.len(), 1);
+}
+
+#[test]
+fn nightly_roundtrip_respects_the_setting_at_every_step() {
+    let mut host = FakeHost::with_release(NIGHTLY_TAG);
+
+    let resolved = resolve_ols_binary(&mut host, &inputs(Some(NIGHTLY_TAG), None)).unwrap();
+    assert_eq!(resolved, format!("ols-nightly/{EXE}"));
+    let nightly_record = host.written_record.clone().unwrap();
+
+    host.release = Some(release("dev-2026-06"));
+    let resolved = resolve_ols_binary(&mut host, &inputs(None, Some(&nightly_record))).unwrap();
+    assert_eq!(resolved, format!("ols-dev-2026-06/{EXE}"));
+    assert_eq!(host.list_ols_dirs(), vec!["ols-dev-2026-06".to_string()]);
+}


### PR DESCRIPTION
Resolving the OLS binary previously ignored user-configured binary arguments/env, and could not target a specific release. New odinfmt config guide to added to readme.