### PR TITLE
feat: inject glsl/hlsl/wgsl/json/sql/html/xml into magic-commented raw strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,22 @@ For detailed information about creating and using snippets, see [Zed's snippet d
 
 ---
 
+## Embedded Language Highlighting
+
+Odin has no native syntax for embedded shaders, markup, queries, or config, so raw strings holding this content render as plain text by default. Add a `// <lang>` comment directly above the raw string to highlight its contents as that language:
+
+```odin
+// glsl
+vert_shader := `void main() { gl_Position = vec4(0); }`
+
+// hlsl
+pixel_shader := `float4 main() : SV_Target { return float4(1, 0, 0, 1); }`
+```
+
+Supported languages: `glsl`, `hlsl`, `wgsl`, `json`, `sql`, `html`, `xml`. The comment must sit immediately above a `:=`, `=`, or `::` raw (backtick) string assignment, and matching is case-insensitive. This only affects syntax highlighting; Zed still needs the corresponding language extension installed (e.g. the GLSL or HLSL extension) to render it.
+
+---
+
 ## Debugging
 
 Debugging uses **CodeLLDB**, which Zed's debugger installs automatically.

--- a/languages/odin/injections.scm
+++ b/languages/odin/injections.scm
@@ -1,2 +1,191 @@
 ((comment) @injection.content
   (#set! injection.language "comment"))
+
+; glsl ------------------------------------------------------------------------
+([
+  ((comment) @_comment
+    .
+    (var_declaration
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+  ((comment) @_comment
+    .
+    (assignment_statement
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+  ((comment) @_comment
+    .
+    (const_declaration
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+]
+  (#match? @_comment "(?i)^//\\s*glsl\\s*$")
+  (#set! injection.language "glsl"))
+
+; hlsl ------------------------------------------------------------------------
+([
+  ((comment) @_comment
+    .
+    (var_declaration
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+  ((comment) @_comment
+    .
+    (assignment_statement
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+  ((comment) @_comment
+    .
+    (const_declaration
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+]
+  (#match? @_comment "(?i)^//\\s*hlsl\\s*$")
+  (#set! injection.language "hlsl"))
+
+; wgsl ------------------------------------------------------------------------
+([
+  ((comment) @_comment
+    .
+    (var_declaration
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+  ((comment) @_comment
+    .
+    (assignment_statement
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+  ((comment) @_comment
+    .
+    (const_declaration
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+]
+  (#match? @_comment "(?i)^//\\s*wgsl\\s*$")
+  (#set! injection.language "wgsl"))
+
+; json ------------------------------------------------------------------------
+([
+  ((comment) @_comment
+    .
+    (var_declaration
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+  ((comment) @_comment
+    .
+    (assignment_statement
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+  ((comment) @_comment
+    .
+    (const_declaration
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+]
+  (#match? @_comment "(?i)^//\\s*json\\s*$")
+  (#set! injection.language "json"))
+
+; sql -------------------------------------------------------------------------
+([
+  ((comment) @_comment
+    .
+    (var_declaration
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+  ((comment) @_comment
+    .
+    (assignment_statement
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+  ((comment) @_comment
+    .
+    (const_declaration
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+]
+  (#match? @_comment "(?i)^//\\s*sql\\s*$")
+  (#set! injection.language "sql"))
+
+; html ------------------------------------------------------------------------
+([
+  ((comment) @_comment
+    .
+    (var_declaration
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+  ((comment) @_comment
+    .
+    (assignment_statement
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+  ((comment) @_comment
+    .
+    (const_declaration
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+]
+  (#match? @_comment "(?i)^//\\s*html\\s*$")
+  (#set! injection.language "html"))
+
+; xml -------------------------------------------------------------------------
+([
+  ((comment) @_comment
+    .
+    (var_declaration
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+  ((comment) @_comment
+    .
+    (assignment_statement
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+  ((comment) @_comment
+    .
+    (const_declaration
+      (string
+        "`"
+        (string_content) @injection.content
+        "`")))
+]
+  (#match? @_comment "(?i)^//\\s*xml\\s*$")
+  (#set! injection.language "xml"))


### PR DESCRIPTION
Odin has no native syntax for embedded query/markup/shader/config text, so a `// <lang>` comment directly above a raw string now triggers language-specific highlighting via injection.