### PR TITLE
feat: allow a custom LLDB script via lsp.ols.settings.lldb_script

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,26 @@ A bundled LLDB formatter is injected into every session, so the Variables panel 
 
 Corrupted values degrade safely: a slice or map with a garbage length or a nil data pointer shows its raw fields instead of freezing the panel or spilling Python errors into the console.
 
+### Using your own LLDB script
+
+To load your own script instead of the bundled formatter, set `lldb_script` in your `lsp.ols.settings` to a path relative to your project root:
+
+```json
+{
+  "lsp": {
+    "ols": {
+      "settings": {
+        "lldb_script": ".zed/my_odin.py"
+      }
+    }
+  }
+}
+```
+
+The script must define `__lldb_init_module(debugger, internal_dict)`, same as `odin.py`. The path is read from within the project (same access extensions have to any other project file), so it must live inside the project; if it can't be read, the bundled formatter is used instead.
+
+This setting is read as part of `lsp.ols.settings`, so it's picked up when the OLS language server starts, not on every debug session. After adding or changing it, restart the language server (or restart Zed) for it to take effect.
+
 ### Custom debug scenarios
 
 For anything beyond run/test — attaching to a process, custom binaries, arguments — add a `.zed/debug.json` to your project:

--- a/src/logic.rs
+++ b/src/logic.rs
@@ -1,6 +1,12 @@
+use base64::{engine::general_purpose, Engine as _};
+
 pub const RELEASE_CHECK_INTERVAL_SECS: u64 = 24 * 60 * 60;
 pub const LAST_RELEASE_CHECK_FILE: &str = ".ols-last-release-check";
 pub const NIGHTLY_TAG: &str = "nightly";
+
+/// Key under `lsp.ols.settings` a user can set to point at a custom LLDB script
+/// that replaces the bundled `odin.py` formatter for every debug session.
+pub const LLDB_SCRIPT_SETTING_KEY: &str = "lldb_script";
 
 pub fn format_check_record(checked_at_secs: u64, version: &str) -> String {
     format!("{checked_at_secs} {version}")
@@ -20,6 +26,25 @@ pub fn release_tag_from_settings(settings: Option<&serde_json::Value>) -> Option
         .map(str::trim)
         .filter(|tag| !tag.is_empty())
         .map(str::to_string)
+}
+
+pub fn lldb_script_from_settings(settings: Option<&serde_json::Value>) -> Option<String> {
+    settings?
+        .get(LLDB_SCRIPT_SETTING_KEY)?
+        .as_str()
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(str::to_string)
+}
+
+/// Builds the `preRunCommands` entry that base64-embeds `script` and runs its
+/// `__lldb_init_module` inside the debug session, working around lldb-dap's
+/// sandboxed `command script import`.
+pub fn lldb_prerun_command(script: &str) -> String {
+    let encoded = general_purpose::STANDARD.encode(script);
+    format!(
+        "script import base64, types; odin = types.SimpleNamespace(); exec(base64.b64decode('{encoded}').decode(), odin.__dict__); odin.__dict__['__lldb_init_module'](lldb.debugger, {{}})"
+    )
 }
 
 pub fn ols_version_dir(version: &str) -> String {
@@ -54,6 +79,7 @@ pub fn use_path_binary(release_tag: Option<&str>) -> bool {
 pub fn strip_extension_settings(settings: &mut serde_json::Value) {
     if let Some(settings) = settings.as_object_mut() {
         settings.remove("release_tag");
+        settings.remove(LLDB_SCRIPT_SETTING_KEY);
     }
 }
 

--- a/src/odin.rs
+++ b/src/odin.rs
@@ -1,4 +1,3 @@
-use base64::{engine::general_purpose, Engine as _};
 use std::fs;
 use zed::{
     BuildTaskDefinition, BuildTaskDefinitionTemplatePayload, BuildTaskTemplate, DebugRequest,
@@ -14,6 +13,7 @@ use zed_extension_api::{
 
 struct OdinExtension {
     cached_binary: Option<CachedBinary>,
+    lldb_script: Option<String>,
 }
 
 struct CachedBinary {
@@ -23,9 +23,10 @@ struct CachedBinary {
 
 mod logic;
 use logic::{
-    debug_output_name, merged_initialization_options, release_tag_from_settings,
-    resolve_ols_binary, strip_extension_settings, use_path_binary, Host, Release, ReleaseAsset,
-    ResolveInputs, LAST_RELEASE_CHECK_FILE,
+    debug_output_name, lldb_prerun_command, lldb_script_from_settings,
+    merged_initialization_options, release_tag_from_settings, resolve_ols_binary,
+    strip_extension_settings, use_path_binary, Host, Release, ReleaseAsset, ResolveInputs,
+    LAST_RELEASE_CHECK_FILE,
 };
 
 const GITHUB_REPO: &str = "DanielGavin/ols";
@@ -45,6 +46,15 @@ impl OdinExtension {
             Os::Windows => "\\",
             _ => "/",
         }
+    }
+
+    /// Loads the LLDB script for a debug session: the script set via `lldb_script`
+    /// in `lsp.ols.settings` (cached from the last time the language server settings
+    /// were read for a worktree), or the bundled `odin.py` if unset.
+    fn resolve_lldb_script(&self) -> String {
+        self.lldb_script
+            .clone()
+            .unwrap_or_else(|| ODIN_SCRIPT.to_string())
     }
 
     fn ols_binary_name(&self, platform: Os, arch: Architecture) -> Option<String> {
@@ -77,6 +87,12 @@ impl OdinExtension {
         worktree: &Worktree,
     ) -> Result<String> {
         let lsp_settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree).ok();
+
+        if let Some(raw_path) =
+            lldb_script_from_settings(lsp_settings.as_ref().and_then(|s| s.settings.as_ref()))
+        {
+            self.lldb_script = worktree.read_text_file(&raw_path).ok();
+        }
 
         if let Some(path) = lsp_settings
             .as_ref()
@@ -252,6 +268,7 @@ impl zed::Extension for OdinExtension {
     fn new() -> Self {
         Self {
             cached_binary: None,
+            lldb_script: None,
         }
     }
 
@@ -515,11 +532,7 @@ impl zed::Extension for OdinExtension {
 
         let mut config_map = serde_json::Map::new();
 
-        let encoded_script = general_purpose::STANDARD.encode(ODIN_SCRIPT);
-        let exec_command = format!(
-            "script import base64, types; odin = types.SimpleNamespace(); exec(base64.b64decode('{}').decode(), odin.__dict__); odin.__dict__['__lldb_init_module'](lldb.debugger, {{}})",
-            encoded_script
-        );
+        let exec_command = lldb_prerun_command(&self.resolve_lldb_script());
 
         config_map.insert(
             "preRunCommands".to_string(),
@@ -592,6 +605,31 @@ impl zed::Extension for OdinExtension {
         };
 
         Ok(DebugRequest::Launch(request))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn extension(lldb_script: Option<&str>) -> OdinExtension {
+        OdinExtension {
+            cached_binary: None,
+            lldb_script: lldb_script.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn resolve_lldb_script_uses_the_bundled_script_by_default() {
+        assert_eq!(extension(None).resolve_lldb_script(), ODIN_SCRIPT);
+    }
+
+    #[test]
+    fn resolve_lldb_script_uses_the_cached_custom_script() {
+        assert_eq!(
+            extension(Some("# custom marker\n")).resolve_lldb_script(),
+            "# custom marker\n"
+        );
     }
 }
 

--- a/tests/logic.rs
+++ b/tests/logic.rs
@@ -2,6 +2,7 @@
 #[path = "../src/logic.rs"]
 mod logic;
 
+use base64::{engine::general_purpose, Engine as _};
 use logic::*;
 use std::collections::BTreeSet;
 
@@ -121,6 +122,7 @@ fn path_binary_is_outranked_by_explicit_pin() {
 fn strip_extension_settings_removes_only_release_tag() {
     let mut settings = serde_json::json!({
         "release_tag": "nightly",
+        "lldb_script": ".zed/my_odin.py",
         "odin_command": "/usr/local/bin/odin",
     });
     strip_extension_settings(&mut settings);
@@ -212,6 +214,43 @@ fn debug_output_names_are_derived_from_the_resolved_label() {
     assert_eq!(debug_output_name("", ""), "debug_build");
     assert_eq!(debug_output_name("run: ''", ""), "debug_build");
     assert_eq!(debug_output_name("test: ///", ".exe"), "debug_build.exe");
+}
+
+#[test]
+fn lldb_script_from_settings_reads_and_trims_the_setting() {
+    assert_eq!(lldb_script_from_settings(None), None);
+    assert_eq!(
+        lldb_script_from_settings(Some(&serde_json::json!({ "odin_command": "odin" }))),
+        None
+    );
+    assert_eq!(
+        lldb_script_from_settings(Some(&serde_json::json!({ "lldb_script": "   " }))),
+        None,
+        "blank paths are treated as unset"
+    );
+    assert_eq!(
+        lldb_script_from_settings(Some(
+            &serde_json::json!({ "lldb_script": " .zed/my_odin.py " })
+        )),
+        Some(".zed/my_odin.py".to_string())
+    );
+}
+
+#[test]
+fn lldb_prerun_command_round_trips_the_script_through_base64() {
+    let script = "# marker\ndef __lldb_init_module(debugger, internal_dict):\n    pass\n";
+    let command = lldb_prerun_command(script);
+
+    assert!(command.starts_with("script import base64, types;"));
+    assert!(command.ends_with("odin.__dict__['__lldb_init_module'](lldb.debugger, {})"));
+
+    let marker = "base64.b64decode('";
+    let start = command.find(marker).unwrap() + marker.len();
+    let end = start + command[start..].find('\'').unwrap();
+    let decoded = general_purpose::STANDARD
+        .decode(&command[start..end])
+        .unwrap();
+    assert_eq!(String::from_utf8(decoded).unwrap(), script);
 }
 
 #[derive(Default)]


### PR DESCRIPTION
Lets users replace the bundled odin.py formatter with their own script by
setting `lldb_script` (a project-relative path) in lsp.ols.settings.